### PR TITLE
add support for automatically finding sdl dependencies for every OS very reliably

### DIFF
--- a/CMAKE/FindSDL2.cmake
+++ b/CMAKE/FindSDL2.cmake
@@ -1,0 +1,254 @@
+# Locate SDL2 library
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2_main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDL2main.h and SDL2main.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2 is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2
+# used in building SDL2.
+# l.e.galup 9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL2 convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
+#
+# Note that on windows this will only search for the 32bit libraries, to search
+# for 64bit change x86/i686-w64 to x64/x86_64-w64
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        PATH_SUFFIXES include/SDL2 include SDL2
+        i686-w64-mingw32/include/SDL2
+        x86_64-w64-mingw32/include/SDL2
+        PATHS
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local/include/SDL2
+        /usr/include/SDL2
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+        )
+
+# Lookup the 64 bit libs on x64
+IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2_LIBRARY_TEMP SDL2
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            PATH_SUFFIXES lib64 lib
+            lib/x64
+            x86_64-w64-mingw32/lib
+            PATHS
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+            )
+    # On 32bit build find the 32bit libs
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2_LIBRARY_TEMP SDL2
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            PATH_SUFFIXES lib
+            lib/x86
+            i686-w64-mingw32/lib
+            PATHS
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+            )
+ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+    IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+        # Non-OS X framework versions expect you to also dynamically link to
+        # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+        # seem to provide SDL2main for compatibility even though they don't
+        # necessarily need it.
+        # Lookup the 64 bit libs on x64
+        IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            FIND_LIBRARY(SDL2MAIN_LIBRARY
+                    NAMES SDL2main
+                    HINTS
+                    ${SDL2}
+                    $ENV{SDL2}
+                    PATH_SUFFIXES lib64 lib
+                    lib/x64
+                    x86_64-w64-mingw32/lib
+                    PATHS
+                    /sw
+                    /opt/local
+                    /opt/csw
+                    /opt
+                    )
+            # On 32bit build find the 32bit libs
+        ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            FIND_LIBRARY(SDL2MAIN_LIBRARY
+                    NAMES SDL2main
+                    HINTS
+                    ${SDL2}
+                    $ENV{SDL2}
+                    PATH_SUFFIXES lib
+                    lib/x86
+                    i686-w64-mingw32/lib
+                    PATHS
+                    /sw
+                    /opt/local
+                    /opt/csw
+                    /opt
+                    )
+        ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+    FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+    SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+SET(SDL2_FOUND "NO")
+IF(SDL2_LIBRARY_TEMP)
+    # For SDL2main
+    IF(NOT SDL2_BUILDING_LIBRARY)
+        IF(SDL2MAIN_LIBRARY)
+            SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+        ENDIF(SDL2MAIN_LIBRARY)
+    ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+    # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+    # CMake doesn't display the -framework Cocoa string in the UI even
+    # though it actually is there if I modify a pre-used variable.
+    # I think it has something to do with the CACHE STRING.
+    # So I use a temporary variable until the end so I can set the
+    # "real" variable in one-shot.
+    IF(APPLE)
+        SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+    ENDIF(APPLE)
+
+    # For threads, as mentioned Apple doesn't need this.
+    # In fact, there seems to be a problem if I used the Threads package
+    # and try using this line, so I'm just skipping it entirely for OS X.
+    IF(NOT APPLE)
+        SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+    ENDIF(NOT APPLE)
+
+    # For MinGW library
+    IF(MINGW)
+        SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+    ENDIF(MINGW)
+
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+
+    SET(SDL2_FOUND "YES")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)

--- a/CMAKE/FindSDL2Mixer - Copy.cmake
+++ b/CMAKE/FindSDL2Mixer - Copy.cmake
@@ -1,0 +1,37 @@
+# OpenClonk, http://www.openclonk.org
+#
+# Copyright (c) 2016, The OpenClonk Team and contributors
+#
+# Distributed under the terms of the ISC license; see accompanying file
+# "COPYING" for details.
+#
+# "Clonk" is a registered trademark of Matthes Bender, used with permission.
+# See accompanying file "TRADEMARK" for details.
+#
+# To redistribute this file separately, substitute the full license texts
+# for the above references.
+
+# Locate SDL_Mixer 2.
+# This module defines
+#  SDL2Mixer_INCLUDE_DIRS - a list of directories that need to be added to the include path
+#  SDL2Mixer_LIBRARIES - a list of libraries to link against to use SDL2
+#  SDL2Mixer_FOUND - if false, SDL2 cannot be used
+
+if(SDL2Mixer_FIND_QUIETLY)
+    set(_FIND_SDL2_ARG QUIET)
+endif()
+
+find_package(SDL2 ${_FIND_SDL2_ARG})
+find_path(SDL2Mixer_INCLUDE_DIR SDL_mixer.h PATH_SUFFIXES SDL2 HINTS ENV SDL2DIR)
+mark_as_advanced(SDL2Mixer_INCLUDE_DIR)
+find_library(SDL2Mixer_LIBRARY SDL2_mixer HINTS ENV SDL2DIR)
+mark_as_advanced(SDL2Mixer_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2Mixer REQUIRED_VARS SDL2Mixer_LIBRARY SDL2Mixer_INCLUDE_DIR
+        SDL2_LIBRARY SDL2_INCLUDE_DIR)
+
+if (SDL2Mixer_FOUND)
+    set(SDL2Mixer_LIBRARIES ${SDL2Mixer_LIBRARY} ${SDL2_LIBRARIES})
+    set(SDL2Mixer_INCLUDE_DIRS ${SDL2Mixer_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
+endif()

--- a/CMAKE/FindSDL2Mixer.cmake
+++ b/CMAKE/FindSDL2Mixer.cmake
@@ -1,0 +1,80 @@
+FIND_PATH(SDL2Mixer_INCLUDE_DIR SDL_mixer.h
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_MIXER}
+        PATH_SUFFIXES include/SDL2 include SDL2
+        i686-w64-mingw32/include/SDL2
+        x86_64-w64-mingw32/include/SDL2
+        PATHS
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local/include/SDL2
+        /usr/include/SDL2
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+        )
+
+# Lookup the 64 bit libs on x64
+IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2Mixer_LIBRARY_TEMP
+            NAMES SDL2_mixer
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            $ENV{SDL2_MIXER}
+            PATH_SUFFIXES lib64 lib
+            lib/x64
+            x86_64-w64-mingw32/lib
+            PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw # Fink
+            /opt/local # DarwinPorts
+            /opt/csw # Blastwave
+            /opt
+            )
+    # On 32bit build find the 32bit libs
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2Mixer_LIBRARY_TEMP
+            NAMES SDL2_mixer
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            $ENV{SDL2_MIXER}
+            PATH_SUFFIXES lib
+            lib/x86
+            i686-w64-mingw32/lib
+            PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw # Fink
+            /opt/local # DarwinPorts
+            /opt/csw # Blastwave
+            /opt
+            )
+ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+SET(SDL2Mixer_FOUND "NO")
+IF(SDL2Mixer_LIBRARY_TEMP)
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2Mixer_LIBRARY ${SDL2Mixer_LIBRARY_TEMP} CACHE STRING "Where the SDL2_mixer Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2Mixer_LIBRARY_TEMP "${SDL2Mixer_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2Mixer_FOUND "YES")
+ENDIF(SDL2Mixer_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2Mixer REQUIRED_VARS SDL2Mixer_LIBRARY SDL2Mixer_INCLUDE_DIR)
+
+if (SDL2Mixer_FOUND)
+    set(SDL2Mixer_LIBRARIES ${SDL2Mixer_LIBRARY} ${SDL2_LIBRARIES})
+    set(SDL2Mixer_INCLUDE_DIRS ${SDL2Mixer_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
+endif()

--- a/CMAKE/FindSDL2TTF.cmake
+++ b/CMAKE/FindSDL2TTF.cmake
@@ -1,0 +1,170 @@
+# Locate SDL2 library
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+SET(SDL2TTF_SEARCH_PATHS
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local
+        /usr
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+        )
+
+FIND_PATH(SDL2TTF_INCLUDE_DIR SDL_ttf.h
+        HINTS
+        $ENV{SDL2TTFDIR}
+        PATH_SUFFIXES include/SDL2 include
+        include/SDL2 include
+        i686-w64-mingw32/include/SDL2
+        x86_64-w64-mingw32/include/SDL2
+        PATHS ${SDL2TTF_SEARCH_PATHS}
+        )
+
+FIND_LIBRARY(SDL2TTF_LIBRARY_TEMP
+        NAMES SDL2_ttf
+        HINTS
+        $ENV{SDL2TTFDIR}
+        PATH_SUFFIXES lib64 lib
+        lib/x64
+        x86_64-w64-mingw32/lib
+        PATHS ${SDL2TTF_SEARCH_PATHS}
+        )
+
+IF(NOT SDL2TTF_BUILDING_LIBRARY)
+    IF(NOT ${SDL2TTF_INCLUDE_DIR} MATCHES ".framework")
+        # Non-OS X framework versions expect you to also dynamically link to
+        # SDL2TTFmain. This is mainly for Windows and OS X. Other (Unix) platforms
+        # seem to provide SDL2TTFmain for compatibility even though they don't
+        # necessarily need it.
+        FIND_LIBRARY(SDL2TTFMAIN_LIBRARY
+                NAMES SDL2_ttf
+                HINTS
+                $ENV{SDL2TTFDIR}
+                PATH_SUFFIXES lib64 lib
+                PATHS ${SDL2TTF_SEARCH_PATHS}
+                )
+    ENDIF(NOT ${SDL2TTF_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2TTF_BUILDING_LIBRARY)
+
+# SDL2TTF may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+    FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2TTFmain -lSDL2TTF -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+    SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+SET(SDL2TTF_FOUND "NO")
+IF(SDL2TTF_LIBRARY_TEMP)
+    # For SDL2TTFmain
+    IF(NOT SDL2TTF_BUILDING_LIBRARY)
+        IF(SDL2TTFMAIN_LIBRARY)
+            SET(SDL2TTF_LIBRARY_TEMP ${SDL2TTFMAIN_LIBRARY} ${SDL2TTF_LIBRARY_TEMP})
+        ENDIF(SDL2TTFMAIN_LIBRARY)
+    ENDIF(NOT SDL2TTF_BUILDING_LIBRARY)
+
+    # For OS X, SDL2TTF uses Cocoa as a backend so it must link to Cocoa.
+    # CMake doesn't display the -framework Cocoa string in the UI even
+    # though it actually is there if I modify a pre-used variable.
+    # I think it has something to do with the CACHE STRING.
+    # So I use a temporary variable until the end so I can set the
+    # "real" variable in one-shot.
+    IF(APPLE)
+        SET(SDL2TTF_LIBRARY_TEMP ${SDL2TTF_LIBRARY_TEMP} "-framework Cocoa")
+    ENDIF(APPLE)
+
+    # For threads, as mentioned Apple doesn't need this.
+    # In fact, there seems to be a problem if I used the Threads package
+    # and try using this line, so I'm just skipping it entirely for OS X.
+    IF(NOT APPLE)
+        SET(SDL2TTF_LIBRARY_TEMP ${SDL2TTF_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+    ENDIF(NOT APPLE)
+
+    # For MinGW library
+    IF(MINGW)
+        SET(SDL2TTF_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2TTF_LIBRARY_TEMP})
+    ENDIF(MINGW)
+
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2TTF_LIBRARY ${SDL2TTF_LIBRARY_TEMP} CACHE STRING "Where the SDL2TTF Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2TTF_LIBRARY_TEMP "${SDL2TTF_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2TTF_FOUND "YES")
+ENDIF(SDL2TTF_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2TTF REQUIRED_VARS SDL2TTF_LIBRARY SDL2TTF_INCLUDE_DIR)

--- a/CMAKE/FindSDL2_IMAGE.cmake
+++ b/CMAKE/FindSDL2_IMAGE.cmake
@@ -1,0 +1,157 @@
+# Locate SDL2_image library
+# This module defines
+# SDL2_IMAGE_LIBRARY, the name of the library to link against
+# SDL2_IMAGE_FOUND, if false, do not try to link to SDL2_image
+# SDL2_IMAGE_INCLUDE_DIR, where to find SDL_image.h
+#
+# Additional Note: If you see an empty SDL2_IMAGE_LIBRARY_TEMP in your configuration
+# and no SDL2_IMAGE_LIBRARY, it means CMake did not find your SDL2_Image library
+# (SDL2_image.dll, libsdl2_image.so, SDL2_image.framework, etc).
+# Set SDL2_IMAGE_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_IMAGE_LIBRARY
+# variable, but when these values are unset, SDL2_IMAGE_LIBRARY does not get created.
+#
+# $SDL2 is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2
+# used in building SDL2.
+# l.e.galup 9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_IMAGE_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL2 convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
+#
+# Note that on windows this will only search for the 32bit libraries, to search
+# for 64bit change x86/i686-w64 to x64/x86_64-w64
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+
+FIND_PATH(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+        HINTS
+        ${SDL2}
+        $ENV{SDL2}
+        $ENV{SDL2_IMAGE}
+        PATH_SUFFIXES include/SDL2 include SDL2
+        i686-w64-mingw32/include/SDL2
+        x86_64-w64-mingw32/include/SDL2
+        PATHS
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local/include/SDL2
+        /usr/include/SDL2
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+        )
+
+# Lookup the 64 bit libs on x64
+IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+            NAMES SDL2_image
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            $ENV{SDL2_IMAGE}
+            PATH_SUFFIXES lib64 lib
+            lib/x64
+            x86_64-w64-mingw32/lib
+            PATHS
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+            )
+    # On 32bit build find the 32bit libs
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+            NAMES SDL2_image
+            HINTS
+            ${SDL2}
+            $ENV{SDL2}
+            $ENV{SDL2_IMAGE}
+            PATH_SUFFIXES lib
+            lib/x86
+            i686-w64-mingw32/lib
+            PATHS
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+            )
+ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+SET(SDL2_IMAGE_FOUND "NO")
+IF(SDL2_IMAGE_LIBRARY_TEMP)
+    # Set the final string here so the GUI reflects the final state.
+    SET(SDL2_IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARY_TEMP} CACHE STRING "Where the SDL2_image Library can be found")
+    # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+    SET(SDL2_IMAGE_LIBRARY_TEMP "${SDL2_IMAGE_LIBRARY_TEMP}" CACHE INTERNAL "")
+    SET(SDL2_IMAGE_FOUND "YES")
+ENDIF(SDL2_IMAGE_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_IMAGE REQUIRED_VARS SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)


### PR DESCRIPTION
copied some files from someone else, worked flawless in my game for Mac, Linux (and Windows (when library files are in certain directories))